### PR TITLE
Setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+# Setup file for tape
+
+from setuptools import setup
+
+description = """\
+A simple Web server which serves static files and do simple proxying"""
+long_description = """\
+Tape is a simple Web server which will serve up a directory of files and do
+simple proxying. It is quite handy when developing Web applications that do not
+depend on application servers."""
+
+setup(name = "tape",
+      description = description,
+      long_description = long_description,
+      license = "GNU General Public License v3",
+      url = "http://github.com/metajack/tape",
+
+      author = "Jack Moffitt",
+      author_email = "jack@metajack.im",
+
+      version = "1.0",
+      scripts = ['tape'],
+      data_files = [('', ['README.markdown', 'LICENSE.txt', 'taperc.example'])],
+      install_requires = ['twisted'],
+
+      classifiers = ["Development Status :: 5 - Production/Stable",
+                     "License :: OSI Approved :: GNU General Public License v3",
+                     "Operating System :: OS Independent",
+                     "Programming Language :: Python :: 2.6",
+                     "Topic :: Utilities"])
+


### PR DESCRIPTION
I written a `setup.py` script to facilitate the installation of tape in a python environment.
This should allow anyone to run this simple command: `python setup.py install`.

The idea is to put the project builds on [Pypi](http://pypi.python.org/pypi).
Thus it would be even easier to install it via pip (`pip install tape`).
For this, the `setup.py`  is only the first step, as we need one more commit to add a `MANIFEST.in` file then register the project on Pypi (this implies to have a maintainer).

I can do all of this if you are ok :)
