### PR TITLE
Solution for exceptions.AttributeError for escape

### DIFF
--- a/tape
+++ b/tape
@@ -4,7 +4,7 @@
 
 import os
 import sys
-import re
+import urllib
 from datetime import datetime
 from optparse import OptionParser
 from ConfigParser import RawConfigParser
@@ -28,13 +28,13 @@ class TapeSite(server.Site):
             request.getClientIP(),
             # request.getUser() or "-", # the remote user is almost never important
             datetime.now(),
-            '%s %s %s' % (re.escape(request.method),
-                          re.escape(request.uri),
-                          re.escape(request.clientproto)),
+            '%s %s %s' % (urllib.quote_plus(request.method),
+                          urllib.quote_plus(request.uri),
+                          urllib.quote_plus(request.clientproto)),
             request.code,
             request.sentLength or "-",
-            re.escape(request.getHeader("referer") or "-"),
-            re.escape(request.getHeader("user-agent") or "-"))
+            urllib.quote_plus(request.getHeader("referer") or "-"),
+            urllib.quote_plus(request.getHeader("user-agent") or "-"))
         sys.stdout.write(line)
 
 


### PR DESCRIPTION
I was getting error : exceptions.AttributeError: TapeSite instance has no attribute '_escape' while running "tape -P /xmpp-httpbind=http://localhost:5290/xmpp-httpbind" 

Attached modifications in file for solution
