### PR TITLE
Fixed broken import on latest twisted.

### DIFF
--- a/tape
+++ b/tape
@@ -13,7 +13,7 @@ from twisted.application import internet
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.web import server, static, proxy
-from twisted.web.error import NoResource
+from twisted.web.resource import NoResource
 from twisted.web.util import redirectTo
 
 


### PR DESCRIPTION
In twisted 16.4.1 NoResource already located in twisted.web.resource instead of twised.web.error